### PR TITLE
Changed read buffer in WiFiClient

### DIFF
--- a/libraries/WiFi/WiFiClient.cpp
+++ b/libraries/WiFi/WiFiClient.cpp
@@ -106,7 +106,7 @@ int WiFiClient::read() {
 int WiFiClient::read(uint8_t* buf, size_t size) {
   if (!ServerDrv::getDataBuf(_sock, buf, &size))
       return -1;
-  return 0;
+  return size;
 }
 
 int WiFiClient::peek() {


### PR DESCRIPTION
Now it returns the number of chararcters read in the buffer, no more
just 0 to say that it has been well read. Seems more logical.
